### PR TITLE
Refactor/toc

### DIFF
--- a/src/components/post/table-of-contents.tsx
+++ b/src/components/post/table-of-contents.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import tw from 'twin.macro';
 
@@ -62,6 +62,33 @@ const TableOfContents = ({ toc }: TableOfContentsProps) => {
   useScrollEvent(() => {
     return EventManager.toFit(onScroll, {})();
   });
+
+  // Link 클릭 시, url에 #이 붙는 것을 막기 위해 preventDefault를 사용하고, scrollTo를 사용하여 이동
+  useEffect(() => {
+    const headerElements = getHeaderElements();
+
+    headerElements.forEach((headerElement) => {
+      if (!headerElement) return;
+
+      const { header, link } = headerElement;
+
+      link.addEventListener('click', (e: Event) => {
+        e.preventDefault();
+
+        const { top } = header.getBoundingClientRect();
+        const elementTop = top + window.scrollY;
+
+        window.scrollTo({
+          top: elementTop - 80,
+          behavior: 'smooth',
+        });
+      });
+
+      return () => {
+        link.removeEventListener('click', () => {});
+      };
+    });
+  }, []);
 
   if (!toc) return null;
 

--- a/src/hooks/use-scroll-event.ts
+++ b/src/hooks/use-scroll-event.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+export const useScrollEvent = (onScroll: () => void) => {
+  useEffect(() => {
+    // scroll event는 이미 스크롤이 발생한 뒤의 로직이기 때문에 { passive: true } 옵션은 무의미함.
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};

--- a/src/libs/dom.ts
+++ b/src/libs/dom.ts
@@ -1,3 +1,9 @@
+/**
+ * Original Code
+ * @see https://github.com/JaeYeopHan/gatsby-starter-bee/blob/master/src/utils/dom.js
+ * modified by @jaem1n207
+ */
+
 const BODY = 'body';
 
 export const getElements = (selector: string) => document.querySelectorAll(selector);

--- a/src/libs/event-manager.ts
+++ b/src/libs/event-manager.ts
@@ -4,8 +4,8 @@
  */
 
 interface EventManagerProps {
-  dismissCondition: () => boolean;
-  triggerCondition: () => boolean;
+  dismissCondition?: () => boolean;
+  triggerCondition?: () => boolean;
 }
 
 export const toFit = (

--- a/src/libs/event-manager.ts
+++ b/src/libs/event-manager.ts
@@ -1,3 +1,8 @@
+/**
+ * Original Code
+ * @see https://github.com/JaeYeopHan/gatsby-starter-bee/blob/master/src/utils/event-manager.js
+ */
+
 interface EventManagerProps {
   dismissCondition: () => boolean;
   triggerCondition: () => boolean;
@@ -5,34 +10,25 @@ interface EventManagerProps {
 
 export const toFit = (
   cb: () => void,
-  { dismissCondition, triggerCondition }: EventManagerProps
+  { dismissCondition = () => false, triggerCondition = () => true }: EventManagerProps
 ) => {
   if (!cb) throw Error('Callback is required');
 
   let tick = false;
 
   return () => {
-    if (dismissCondition()) return;
-    if (triggerCondition()) {
-      cb();
-      return;
-    }
-    if (!tick) {
-      tick = true;
-      requestAnimationFrame(() => {
-        tick = false;
-        toFit(cb, { dismissCondition, triggerCondition })();
-      });
-    }
-  };
+    if (tick) return;
 
-  // const loop = () => {
-  //   if (dismissCondition()) return;
-  //   if (triggerCondition()) {
-  //     cb();
-  //     return;
-  //   }
-  //   requestAnimationFrame(loop);
-  // };
-  // loop();
+    tick = true;
+    return requestAnimationFrame(() => {
+      if (dismissCondition()) {
+        tick = false;
+        return;
+      }
+      if (triggerCondition()) {
+        tick = false;
+        return cb();
+      }
+    });
+  };
 };

--- a/src/libs/scroll.ts
+++ b/src/libs/scroll.ts
@@ -1,6 +1,8 @@
 /**
- * @fileoverview Scroll to anchor link with smooth scroll polyfill and smooth-scroll library
+ * Original Code
  * @see https://github.com/JaeYeopHan/gatsby-starter-bee/blob/master/src/utils/scroll.js
+ * @fileoverview Scroll to anchor link with smooth scroll polyfill and smooth-scroll library
+ * modified by @jaem1n207
  */
 
 // https://github.com/cferdinandi/smooth-scroll/issues/481


### PR DESCRIPTION
## Describe your changes
- `intersectionObserver`가 아닌 `Scroll Event`를 사용하여 header 위치 판단. 낮아진 효율성은 `Scroll Event`에 Task Queue(Event Queue)대신 Animation frames(rAF)으로 처리되도록 함.
> IntersectionObserver를 통한 계산값으로 스크롤을 헤더 위로 올렸을때 하이라이팅을 제거하도록해서 css class를 toggle시키는 방법을 선택했었다. 하지만, header #경로로 이동할 때 스크롤의 속도가 너무 빨라 isIntersection true가 발생하지않아 toggle이 꼬이는 상황이 발생하였다. 그래서 방법을 위와 같이 수정한다.
- `Link` 클릭 시, url에 #이 붙는 것을 막기 위해 `preventDefault`를 사용하고, `scrollTo`를 사용하여 이동하도록 수정 -> **뒤로가기 불편함 개선**
- scroll-event hook 개발
- event-manager interface 및 로직 수정
- code 저작권 표시

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

## Resource
- https://jbee.io/web/optimize-scroll-event/