### PR TITLE
PATCH: html 문자열 파싱 로직 수정

### DIFF
--- a/src/apps/search/flex-search.tsx
+++ b/src/apps/search/flex-search.tsx
@@ -8,15 +8,17 @@ import HighlightMatches from './highlight-matches';
 import Search from './search';
 import type { PageIndex, Result, SearchResult, SectionIndex } from './types';
 
-// 추후에 추가될 영문 지원을 위해 locale을 인자로 받아서 처리하도록
+// TODO: 추후에 추가될 영문 지원을 위해 locale을 인자로 받아서 처리하도록
 const locale = 'ko';
 
+// locale에 따른 검색 인덱스를 저장하는 객체
 const indexes: {
   [locale: string]: [PageIndex, SectionIndex];
 } = {};
 
-// index 로드하는 promise를 캐싱하기 위한 map
+// 검색 인덱스 로드를 위한 Promise를 캐싱하는 객체
 const loadIndexesPromises = new Map<string, Promise<void>>();
+
 const loadIndexes = (locale: string): Promise<void> => {
   const key = `@${locale}`;
   if (loadIndexesPromises.has(key)) {
@@ -29,7 +31,7 @@ const loadIndexes = (locale: string): Promise<void> => {
 };
 
 const loadIndexesImpl = async (locale: string) => {
-  // 서버측에서 직렬화한 데이터를 가져옵니다.
+  // 빌드 타임 때 생성한 검색 데이터를 가져옵니다.
   const searchData = await fetch(`/lazy-dev-data-${locale}.json`).then<SearchData>((res) =>
     res.json(),
   );
@@ -66,8 +68,8 @@ const loadIndexesImpl = async (locale: string) => {
     },
   });
 
+  // 각 페이지와 섹션에 대해 인덱스를 추가합니다.
   let pageId = 0;
-
   for (const [route, StructuredData] of Object.entries(searchData)) {
     let pageContent = '';
     ++pageId;

--- a/src/apps/search/search.tsx
+++ b/src/apps/search/search.tsx
@@ -39,6 +39,8 @@ const isSearchItem = (el?: HTMLElement) => {
 };
 
 const Search = ({ value, onChange: _onChange, loading, error, results }: SearchProps) => {
+  // 현재로선 search 컴포넌트는 tablet 사이즈 이하인 기기에선 보이지 않습니다.
+  // 그러나 추후 tablet 사이즈 이하인 기기도 검색을 사용할 수 있도록 지원할 예정이기에 아래 조건을 추가합니다.
   const displayKbd =
     !window.__LAZY_DEV_DATA__.detectDevice.isTouch &&
     window.__LAZY_DEV_DATA__.detectDevice.isDesktop;
@@ -161,17 +163,17 @@ const Search = ({ value, onChange: _onChange, loading, error, results }: SearchP
         />
       )}
 
-      <div className="relative flex items-center">
+      <div className="relative flex flex-none items-center gap-2pxr rounded-lg bg-gray-200 px-8pxr py-4pxr dark:bg-gray-50/10">
         <input
           ref={inputRef}
-          className="z-20 block w-full appearance-none rounded-lg bg-gray-200 px-12pxr py-8pxr text-sm -outline-offset-2 transition-colors placeholder-shown:line-clamp-1 dark:bg-gray-50/10 tablet:text-base"
+          className="z-20 flex w-full flex-shrink flex-grow basis-auto appearance-none bg-transparent text-sm -outline-offset-2 transition-colors placeholder-shown:line-clamp-1 focus-within:outline-none  tablet:text-base"
           value={value}
           onChange={onChange}
           placeholder="주제, 내용 검색"
         />
         <ClientOnly>
           {displayKbd && (
-            <div className="absolute right-1 z-20 select-none">
+            <div className="select-none">
               {value ? <Kbd>ESC</Kbd> : <Kbd keys="command">K</Kbd>}
             </div>
           )}

--- a/src/hooks/use-rect.ts
+++ b/src/hooks/use-rect.ts
@@ -86,7 +86,7 @@ const isRefTarget = (
   typeof (eventOrRef as any)?.target === 'undefined';
 
 /**
- * 주어진 `ref` 또는 이벤트에 대한 위치와 크기를 반환합니다.
+ * 주어진 `ref` 또는 이벤트가 발생한 `DOM` 요소의 위치와 크기를 반환합니다.
  */
 export const useRect = (initialState?: ReactiveDomReact | (() => ReactiveDomReact)) => {
   const [rect, setRect] = useState<ReactiveDomReact>(initialState || defaultRect);


### PR DESCRIPTION
##  요약

- 전달 받은 `html` 문자열에서 첫 헤딩 요소 이전 콘텐츠도 검색 데이터로 활용할 수 있도록 수정
- `Search` 컴포넌트에서 `input` 요소의 텍스트와 `kbd` 요소가 겹치지 않도록 스타일 수정